### PR TITLE
Add Vagrant box config files  to create resources for latest WSO2 products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ hs_err_pid*
 .vagrant/
 .idea/
 output/*.box
-build.sh
-box_definitions.rb

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ The local copy of the `vagrant-boxes` directory will be referred to as `VAGARNT-
 
       [JDK 8u144-linux-x64.tar](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) and [WSO2 Update Manager](https://wso2.com/wum/download).
 
-   ii. WSO2 API Manager 2.1.0
+   ii. WSO2 API Manager 2.6.0
 
-      [WSO2 API Manager 2.1.0](https://wso2.com/api-management/#download).
+      [WSO2 API Manager 2.6.0](https://wso2.com/api-management/#download).
 
-   iii. WSO2 Enterprise Integrator 6.2.0
+   iii. WSO2 Enterprise Integrator 6.4.0
 
-      [WSO2 Enterprise Integrator 6.2.0](https://wso2.com/integration#download).
+      [WSO2 Enterprise Integrator 6.4.0](https://wso2.com/integration#download).
 
-   iv. WSO2 Identity Server 5.5.0
+   iv. WSO2 Identity Server 5.7.0
 
-      [WSO2 Identity Server 5.5.0](https://wso2.com/identity-and-access-management#download).
+      [WSO2 Identity Server 5.7.0](https://wso2.com/identity-and-access-management#download).
 
-   v. Stream Processor 4.1.0
+   v. Stream Processor 4.3.0
 
-      [WSO2 Stream Processor 4.1.0](https://wso2.com/analytics#download).
+      [WSO2 Stream Processor 4.3.0](https://wso2.com/analytics#download).
 
    vi. IoT Server 3.3.0
 
@@ -56,7 +56,7 @@ Note: Adding WSO2 Update Manager is optional. Read more about [WSO2 Update Manag
 ```
 3. Edit the config.yaml as required (Comment out the unnecessary box entries).
 
-WSO2 API Manager 2.1.0
+WSO2 API Manager 2.6.0
 ```
 ---
 boxes:
@@ -74,44 +74,34 @@ boxes:
       - 8280
       - 8243
     resources:
-      - wso2am-2.2.0.zip
+      - wso2am-2.6.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2am
-      - version: 2.2.0
+      - version: 2.6.0
   -
     output_box: wso2am-analytics
     base_box: ubuntu/trusty64
     ip: 172.28.128.5
     resources:
-      - wso2am-analytics-2.2.0.zip
+      - wso2am-analytics-2.6.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2am-analytics
-      - version: 2.2.0
+      - version: 2.6.0
   -
     output_box: wso2is-as-km
     base_box: ubuntu/trusty64
     ip: 172.28.128.6
     resources:
-      - wso2is-km-5.5.0.zip
+      - wso2is-km-5.7.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2is-as-km
-      - version: 5.5.0
-  -
-    output_box: wso2am-micro-gw
-    base_box: ubuntu/trusty64
-    ip: 172.28.128.7
-    resources:
-      - wso2am-micro-gw-2.2.0.zip
-    provisioner_script: provisioner/provisioner.sh
-    provisioner_script_args:
-      - server: wso2am-micro-gw
-      - version: 2.2.0
+      - version: 5.7.0
 
 ```
-WSO2 Enterprise Integrator 6.2.0
+WSO2 Enterprise Integrator 6.4.0
 ```
 ---
 boxes:
@@ -127,14 +117,14 @@ boxes:
     ports:
       - 9444
     resources:
-      - wso2ei-6.2.0.zip
+      - wso2ei-6.4.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2ei
-      - version: 6.2.0
+      - version: 6.4.0
 
 ```
-WSO2 Identity Server 5.5.0
+WSO2 Identity Server 5.7.0
 ```
 ---
 boxes:
@@ -150,11 +140,11 @@ boxes:
     ports:
       - 9443
     resources:
-      - wso2is-5.5.0.zip
+      - wso2is-5.7.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2is
-      - version: 5.5.0
+      - version: 5.7.0
   -
     output_box: wso2is-analytics
     base_box: ubuntu/trusty64
@@ -162,13 +152,13 @@ boxes:
     ports:
       - 9444
     resources:
-      - wso2is-analytics-5.5.0.zip
+      - wso2is-analytics-5.7.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2is-analytics
-      - version: 5.5.0
+      - version: 5.7.0
 ```
-Stream Processor 4.1.0
+Stream Processor 4.3.0
 ```
 ---
 boxes:
@@ -182,11 +172,11 @@ boxes:
     base_box: ubuntu/trusty64
     ip: 172.28.128.4
     resources:
-      - wso2sp-4.1.0.zip
+      - wso2sp-4.3.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2sp
-      - version: 4.1.0
+      - version: 4.3.0
 ```
 IoT Server 3.3.0
 ```
@@ -240,3 +230,5 @@ within the `config.yaml` file) is as follows:
 ```
 vagrant box add wso2am output/wso2am.box
 ```
+
+NOTE: The build.sh and box_definitions.rb scripts can be used to do the above steps [4-6] automatically.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,14 +27,14 @@ if ARGV[0] == 'up'
   print "\n"
 else
   # initializing USERNAME and PASSWORD
-  USERNAME = ""
-  PASSWORD = ""
+    USERNAME = ""
+    PASSWORD = ""
 end
 
 FILES_PATH = "./files/"
 JDK_ARCHIVE = "jdk-8u144-linux-x64.tar.gz"
 MYSQL_CONNECTOR = "mysql-connector-java-5.1.45-bin.jar"
-WUM_ARCHIVE = "wum-2.0-linux-x64.tar.gz"
+WUM_ARCHIVE = "wum-3.0.1-linux-x64.tar.gz"
 DEFAULT_MOUNT = "/home/vagrant/"
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure

--- a/box_definitions.rb
+++ b/box_definitions.rb
@@ -1,0 +1,31 @@
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- mode: ruby -*-
+
+require 'yaml'
+require 'fileutils'
+
+# load server configurations from YAML file
+CONFIGURATIONS = YAML.load_file('config.yaml')
+# create an empty array to hold box names
+boxnames=Array.new
+
+# loop through each box specification
+CONFIGURATIONS['boxes'].each do |box|
+  # add box name to array of box names
+  boxnames.push box['output_box']
+end
+
+puts boxnames

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+# This script acts as the Vagrant box build process manager.
+
+set -e
+
+# load box names from definitions
+OUTPUT=$(ruby box_definitions.rb)
+
+# loop through all defined box names and create box files
+for box in ${OUTPUT}
+do
+    vagrant up $box
+    vagrant package $box --output output/$box.box
+    vagrant box add $box output/$box.box
+    vagrant destroy $box -f
+done

--- a/config.yaml
+++ b/config.yaml
@@ -28,21 +28,21 @@ boxes:
       - 8280
       - 8243
     resources:
-      - wso2am-2.2.0.zip
+      - wso2am-2.6.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2am
-      - version: 2.2.0
+      - version: 2.6.0
   -
     output_box: wso2am-analytics
     base_box: ubuntu/trusty64
     ip: 172.28.128.5
     resources:
-      - wso2am-analytics-2.2.0.zip
+      - wso2am-analytics-2.6.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2am-analytics
-      - version: 2.2.0
+      - version: 2.6.0
   -
     output_box: wso2ei
     base_box: ubuntu/trusty64
@@ -50,11 +50,11 @@ boxes:
     ports:
       - 9444
     resources:
-      - wso2ei-6.2.0.zip
+      - wso2ei-6.4.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2ei
-      - version: 6.2.0
+      - version: 6.4.0
   -
     output_box: wso2is
     base_box: ubuntu/trusty64
@@ -62,11 +62,11 @@ boxes:
     ports:
       - 9443
     resources:
-      - wso2is-5.5.0.zip
+      - wso2is-5.7.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2is
-      - version: 5.5.0
+      - version: 5.7.0
   -
     output_box: wso2is-analytics
     base_box: ubuntu/trusty64
@@ -74,41 +74,31 @@ boxes:
     ports:
       - 9444
     resources:
-      - wso2is-analytics-5.5.0.zip
+      - wso2is-analytics-5.7.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2is-analytics
-      - version: 5.5.0
+      - version: 5.7.0
   -
     output_box: wso2am-is-as-km
     base_box: ubuntu/trusty64
     ip: 172.28.128.6
     resources:
-      - wso2is-km-5.5.0.zip
+      - wso2is-km-5.7.0.zip
     provisioner_script: provisioner/provisioner.sh
     provisioner_script_args:
       - server: wso2is-km
-      - version: 5.5.0
-  -
-    output_box: wso2am-micro-gateway
-    base_box: ubuntu/trusty64
-    ip: 172.28.128.7
-    resources:
-      - wso2am-micro-gw-2.2.0.zip
-    provisioner_script: provisioner/provisioner.sh
-    provisioner_script_args:
-      - server: wso2am-micro-gw
-      - version: 2.2.0
+      - version: 5.7.0
   -
    output_box: wso2sp
    base_box: ubuntu/trusty64
    ip: 172.28.128.4
    resources:
-     - wso2sp-4.1.0.zip
+     - wso2sp-4.3.0.zip
    provisioner_script: provisioner/provisioner.sh
    provisioner_script_args:
      - server: wso2sp
-     - version: 4.1.0
+     - version: 4.3.0
   -
    output_box: wso2iot
    base_box: ubuntu/trusty64

--- a/provisioner/provisioner.sh
+++ b/provisioner/provisioner.sh
@@ -25,7 +25,7 @@ USERNAME=$3
 PASSWORD=$4
 WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}.zip
 WSO2_SERVER_UPDATED_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}.*.zip
-WUM_ARCHIVE=wum-2.0-linux-x64.tar.gz
+WUM_ARCHIVE=wum-3.0.1-linux-x64.tar.gz
 WORKING_DIRECTORY=/home/vagrant
 WUM_HOME=/usr/local/
 WUM_PATH='PATH=$PATH:/usr/local/wum/bin'
@@ -58,13 +58,13 @@ export WUM_PATH
 echo "Getting the ${WSO2_SERVER}-${WSO2_SERVER_VERSION} latest pack."
 wum init -u ${USERNAME} -p ${PASSWORD}
 wum add --file ${WORKING_DIRECTORY}/${WSO2_SERVER_PACK}
-wum update
+wum update ${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 
 if [ ! - f ${WUM_PRODUCT_LOCATION}/${WSO2_SERVER_UPDATED_PACK} ]; then
   echo "No updated pack. Use the GA pack instead."
 else
   echo "moving product pack to ${WORKING_DIRECTORY}"
-  mv ${WUM_PRODUCT_LOCATION}/${WSO2_SERVER_UPDATED_PACK} ${WORKING_DIRECTORY}/${WSO2_SERVER_PACK}
+  mv ${WUM_PRODUCT_LOCATION}/${WSO2_SERVER_PACK} ${WORKING_DIRECTORY}/${WSO2_SERVER_PACK}
 fi
 
 echo "removing common wum user credentails"
@@ -74,7 +74,7 @@ sed -i "s/accesstoken:.*/accesstoken:/" /root/.wum-wso2/config.yaml
 echo "wum credentials and app keys removed Successfully"
 
 echo "Removing unnecessary files."
-rm -rf /root/.wum-wso2/updates
+rm -rf /root/.wum3/updates
 rm -rf ${WUM_PRODUCT_LOCATION}/${WSO2_SERVER_PACK}
 rm -rf ${WUM_ARCHIVE}
 rm -rf /tmp/wum*


### PR DESCRIPTION
## Purpose

Add config files to create Vagrant boxes for the following WSO2 Product versions.

- API Manager 2.6.0
- Identity Server 5.7.0
- Stream Processor 4.3.0
- Enterprise Integrator 6.4.0

Resolves https://github.com/wso2/vagrant-boxes/issues/17

## Goals
Create Vagrant boxes for the following WSO2 Product versions.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Vagrant 2.1.5
Ubuntu 14.04